### PR TITLE
Replaced admin_media_prefix usage in mezzanine-templates

### DIFF
--- a/mezzanine_themes/mezzanine_default/templates/admin/index.html
+++ b/mezzanine_themes/mezzanine_default/templates/admin/index.html
@@ -4,7 +4,7 @@
 
 {% block extrahead %}
 {{ block.super }}
-<link rel="stylesheet" href="{% load adminmedia %}{% admin_media_prefix %}css/dashboard.css" />
+<link rel="stylesheet" href="{{ STATIC_URL }}admin/css/dashboard.css" />
 <link rel="stylesheet" href="{{ STATIC_URL }}mezzanine/css/admin/dashboard.css">
 <!--[if IE 7]><style>.dashboard #content {padding-top: 80px;}</style><![endif]-->
 {% endblock %}

--- a/mezzanine_themes/mezzanine_default/templates/admin/login.html
+++ b/mezzanine_themes/mezzanine_default/templates/admin/login.html
@@ -3,7 +3,7 @@
 
 {% block stylesheets %}
 {{ block.super }}
-<link rel="stylesheet" type="text/css" href="{% load adminmedia %}{% admin_media_prefix %}css/login.css">
+<link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}admin/css/login.css">
 {% endblock %}
 
 {% block bodyclass %}login{% endblock %}

--- a/mezzanine_themes/mezzanine_default/templates/admin/pages/page/change_list.html
+++ b/mezzanine_themes/mezzanine_default/templates/admin/pages/page/change_list.html
@@ -1,13 +1,13 @@
 {% extends "admin/change_list.html" %}
-{% load pages_tags i18n future adminmedia %}
+{% load pages_tags i18n future %}
 
 {% block extrahead %}
 {{ block.super }}
 <link rel="stylesheet" href="{{ STATIC_URL }}mezzanine/css/admin/page_tree.css">
 <style>
-.delete {width:10px; height:10px; margin:2px 4px 0 10px; display:block; float:right; background:url('{% admin_media_prefix %}img/admin/icon_deletelink.gif');}
-.grappelli-delete {width:11px; height:11px; margin:4px 4px 0 10px; background:url('{% admin_media_prefix %}img/icons/icon-inline_item_tools-deletelink.png');}
-.grappelli-delete:hover {background:url('{% admin_media_prefix %}img/icons/icon-inline_item_tools-deletelink-hover.png');}
+    .delete {width:10px; height:10px; margin:2px 4px 0 10px; display:block; float:right; background:url('{{ STATIC_URL }}admin/img/admin/icon_deletelink.gif');}
+.grappelli-delete {width:11px; height:11px; margin:4px 4px 0 10px; background:url('{{ STATIC_URL }}admin/img/icons/icon-inline_item_tools-deletelink.png');}
+.grappelli-delete:hover {background:url('{{ STATIC_URL }}admin/img/icons/icon-inline_item_tools-deletelink-hover.png');}
 </style>
 <script>window.__page_ordering_url = '{% url "admin_page_ordering" %}';</script>
 <script src="{{ STATIC_URL }}mezzanine/js/jquery-ui-1.9.1.custom.min.js"></script>

--- a/mezzanine_themes/mezzanine_default/templates/pages/menus/admin.html
+++ b/mezzanine_themes/mezzanine_default/templates/pages/menus/admin.html
@@ -1,4 +1,4 @@
-{% load pages_tags i18n future adminmedia %}
+{% load pages_tags i18n future %}
 
 <ol>
     {% for page in page_branch %}
@@ -23,8 +23,8 @@
             {% endif %}
             <span class="ordering"{% if not page.perms.change %}
                 style="visibility:hidden;"{% endif %}>
-                <img src="{% admin_media_prefix %}img/admin/arrow-up.gif" />
-                <img src="{% admin_media_prefix %}img/admin/arrow-down.gif" />
+                <img src="{{ STATIC_URL }}admin/img/admin/arrow-up.gif" />
+                <img src="{{ STATIC_URL }}admin/img/admin/arrow-down.gif" />
             </span>
             {% if page.perms.add %}
             <select class="addlist" id="addlink-{{ page.id }}">


### PR DESCRIPTION
Hi Renyi,

It looks like the problem was just in the mezzanine_default templates.  I removed references to "adminmedia" and replaced the use of "{% admin_media_prefix %}" with "{{ STATIC_URL }}admin/" in the four templates where it was used.

There are three other templates that reference the ADMIN_MEDIA_PREFIX setting, but I left those alone.  They didn't interfere with my use of the templates.

Cheers,

Tom
