### PR TITLE
Added 'img' folder to 'static' folder. Also generated blank __init__.…

### DIFF
--- a/themeBuilder.sh
+++ b/themeBuilder.sh
@@ -15,9 +15,11 @@ fi
 cd mezzanine_themes
 mkdir $themeName
 cd $themeName
+echo "" > __init__.py
 mkdir static
 mkdir templates
 cd static
+mkdir img
 mkdir js
 mkdir css
 cd ../templates


### PR DESCRIPTION
I added an 'img' folder to the static folder. I also added an automatically genertated __init__.py file for a new theme so that django's settings.py will accept it; I know that the idea was to not have any python code, but without the __init__.py file, you get an error message saying "no such module".