### PR TITLE
Changed class="span*" to class="col-md-*"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *sublime*
 gnuTheme
+bo*/

--- a/mezzanine_themes/business/templates/base.html
+++ b/mezzanine_themes/business/templates/base.html
@@ -46,83 +46,94 @@ $(function() {
 
 </head>
 <body id="{% block body_id %}body{% endblock %}">
-
-<div id="header" class="container">
+    
+<div id="wrapper" class="container">
     <div class="row">
-        <div id="site-info" class="span6">
-            <div id="site-logo"><a href="/"><img src="{{ STATIC_URL }}img/logo.png" /></a></div>
-            <div id="site-titles">
-            {% if settings.SITE_TITLE %}<div id="site-title"><a href="/">{{ settings.SITE_TITLE }}</a></div>{% endif %}
-            {% if settings.SITE_TAGLINE %}<div id="site-tagline">{{ settings.SITE_TAGLINE }}</div>{% endif %}
+    <div class="col-md-2"></div>
+    
+    <div class="col-md-8">
+    <div id="header" class="container">
+        <div class="row">
+            <div id="site-info" class="col-md-6">
+                <div id="site-logo"><a href="/"><img src="{{ STATIC_URL }}img/logo.png" /></a></div>
+                <div id="site-titles">
+                {% if settings.SITE_TITLE %}<div id="site-title"><a href="/">{{ settings.SITE_TITLE }}</a></div>{% endif %}
+                {% if settings.SITE_TAGLINE %}<div id="site-tagline">{{ settings.SITE_TAGLINE }}</div>{% endif %}
+                </div>
+            </div>
+            <div id="navigation" class="col-md-6">
+                {% page_menu "pages/menus/dropdown.html" %}
             </div>
         </div>
-        <div id="navigation" class="span6">
-            {% page_menu "pages/menus/dropdown.html" %}
-        </div>
     </div>
-</div>
 
-<div id="main" class="container">
-
-    {% nevercache %}
-    {% for message in messages %}
-    <div class="alert alert-{{ message.tags }}" data-alert="alert">
-    <a class="close" href="#" onclick="$(this).parent().fadeOut('fast'); return false;">×</a>{{ message }}
-    </div>
-    {% endfor %}
-    {% endnevercache %}
-
-    {% block full %}
-    <div class="row">
-
-        <div class="span9 middle">
-
-            <ul class="breadcrumb-custom">
-            {% spaceless %}
-            {% block breadcrumb_menu %}{% page_menu "pages/menus/breadcrumb.html" %}{% endblock %}
-            {% endspaceless %}
-            </ul>
-
-            <h1>{% block title %}{% endblock %}</h1>
-
-            {% block main %}{% endblock %}
-
+    <div id="main" class="container">
+    
+        {% nevercache %}
+        {% for message in messages %}
+        <div class="alert alert-{{ message.tags }}" data-alert="alert">
+        <a class="close" href="#" onclick="$(this).parent().fadeOut('fast'); return false;">×</a>{{ message }}
         </div>
-
-        <div class="span3 right">
-
-            <div class="panel">
-            {% block right_panel %}
-            {% ifinstalled mezzanine.twitter %}
-            {% include "twitter/tweets.html" %}
-            {% endifinstalled %}
-            {% endblock %}
+        {% endfor %}
+        {% endnevercache %}
+    
+        {% block full %}
+        <div class="row">
+    
+            <div class="col-md-9 middle">
+    
+                <ul class="breadcrumb-custom">
+                {% spaceless %}
+                {% block breadcrumb_menu %}{% page_menu "pages/menus/breadcrumb.html" %}{% endblock %}
+                {% endspaceless %}
+                </ul>
+    
+                <h1>{% block title %}{% endblock %}</h1>
+    
+                {% block main %}{% endblock %}
+    
             </div>
-
+    
+            <div class="col-md-3 right">
+    
+                <div class="panel">
+                {% block right_panel %}
+                {% ifinstalled mezzanine.twitter %}
+                {% include "twitter/tweets.html" %}
+                {% endifinstalled %}
+                {% endblock %}
+                </div>
+    
+            </div>
+    
+        </div><!-- /row -->
+        {% endblock %}
+    
+    </div><!-- /container #main -->
+    
+    <div id="footer-line" class="container">
+        <div class="row">
+        <div class="col-md-6">
+        {% include "includes/footer_text.html" %}
         </div>
-
-    </div><!-- /row -->
-    {% endblock %}
-
-</div><!-- /container #main -->
-
-<div id="footer-line" class="container">
-    <div class="row">
-    <div class="span6">
-    {% include "includes/footer_text.html" %}
+        <div id="footer-powered" class="col-md-6">
+        {% include "includes/footer_powered.html" %}
+        <a onclick="scrollToTop();return false;" href="#"><i class="icon-arrow-up"></i></a>
+        </div>
+        </div>
     </div>
-    <div id="footer-powered" class="span6">
-    {% include "includes/footer_powered.html" %}
-    <a onclick="scrollToTop();return false;" href="#"><i class="icon-arrow-up"></i></a>
+    
+    <div id="footer" class="container">
+        {% page_menu "pages/menus/footer.html" %}
     </div>
+    
     </div>
-</div>
-
-<div id="footer" class="container">
-    {% page_menu "pages/menus/footer.html" %}
-</div>
-
+    
+    </div>
+    
 {% include "includes/footer_scripts.html" %}
+    <div class="col-md-2"></div>
+</div>
 
 </body>
 </html>

--- a/mezzanine_themes/business/templates/index.html
+++ b/mezzanine_themes/business/templates/index.html
@@ -19,7 +19,7 @@
 {% block full %}
 <div id="topblock" class="row">
 
-<div id="toptext" class="span6 left">
+<div id="toptext" class="col-md-6 left">
 
     <h1>{% trans "Best company slogan is here!" %}</h1>
     <ul id="toplist">
@@ -31,7 +31,7 @@
 
 </div>
 
-<div class="span6 right">
+<div class="col-md-6 right">
     <img class="thumbnail" src="http://ipsumimage.appspot.com/440x240" />
 </div>
 
@@ -39,19 +39,19 @@
 
 <div class="row">
 
-<div class="span4">
+<div class="col-md-4">
 
     <h2>Topic</h2>
     <p>Aliquam aliquam laoreet eleifend. Nulla ac risus sed nisi rutrum facilisis. Nulla pharetra leo egestas felis porttitor ornare id at sem. Praesent vitae lorem erat, posuere iaculis dolor. Maecenas adipiscing lectus sit amet tellus lacinia nec blandit libero dignissim.</p>
 
 </div>
-<div class="span4">
+<div class="col-md-4">
 
     <h2>Topic</h2>
     <p>Lorem ipsum dolor sit amet, consectetur <strong>adipiscing</strong> elit. Ut interdum ultrices odio non ornare. Fusce vehicula sem sed neque porttitor pretium. Duis hendrerit nibh id dui mattis euismod. Nulla rhoncus <em>nibh pharetra</em> sem convallis tincidunt.</p>
 
 </div>
-<div class="span4">
+<div class="col-md-4">
 
     <h2>Topic</h2>
     <p>Aliquam aliquam laoreet eleifend. Nulla ac risus sed nisi rutrum facilisis. Nulla pharetra leo egestas felis porttitor ornare id at sem. Praesent vitae lorem erat, posuere iaculis dolor. Maecenas adipiscing lectus sit amet tellus lacinia nec blandit libero dignissim.</p>

--- a/mezzanine_themes/classic/templates/base.html
+++ b/mezzanine_themes/classic/templates/base.html
@@ -49,14 +49,14 @@ $(function() {
 
 <div id="header" class="container">
     <div class="row">
-        <div id="site-info" class="span6">
+        <div id="site-info" class="col-md-6">
             <div id="site-logo"><a href="/"><img src="{{ STATIC_URL }}img/logo.png" /></a></div>
             <div id="site-titles">
             {% if settings.SITE_TITLE %}<div id="site-title"><a href="/">{{ settings.SITE_TITLE }}</a></div>{% endif %}
             {% if settings.SITE_TAGLINE %}<div id="site-tagline">{{ settings.SITE_TAGLINE }}</div>{% endif %}
             </div>
         </div>
-        <div id="user-info" class="span6">
+        <div id="user-info" class="col-md-6">
             {% nevercache %}
             {% include "includes/user_panel.html" %}
             {% endnevercache %}
@@ -85,7 +85,7 @@ $(function() {
     {% block full %}
     <div class="row">
 
-        <div class="span9 middle">
+        <div class="col-md-9 middle">
 
             <ul class="breadcrumb-custom">
             {% spaceless %}
@@ -99,7 +99,7 @@ $(function() {
 
         </div>
 
-        <div class="span3 right">
+        <div class="col-md-3 right">
 
             <div class="panel">
             {% block right_panel %}
@@ -118,10 +118,10 @@ $(function() {
 
 <div id="footer-line" class="container">
     <div class="row">
-    <div class="span6">
+    <div class="col-md-6">
     {% include "includes/footer_text.html" %}
     </div>
-    <div id="footer-powered" class="span6">
+    <div id="footer-powered" class="col-md-6">
     {% include "includes/footer_powered.html" %}
     <a onclick="scrollToTop();return false;" href="#"><i class="icon-arrow-up"></i></a>
     </div>

--- a/mezzanine_themes/classic/templates/includes/user_panel.html
+++ b/mezzanine_themes/classic/templates/includes/user_panel.html
@@ -1,4 +1,4 @@
-{% load mezzanine_tags i18n include_strip future %}
+{% load mezzanine_tags i18n future %}
 <div id="user-welcome">
 {% spaceless %}
 {% trans "Welcome" %}{% ifinstalled mezzanine.accounts %},


### PR DESCRIPTION
Changed class="span*" to class="col-md-*" in business, classic versions of base.html to work with newer version of Bootstrap (this may create backward-incompatible changes with older versions of  Mezzanine that use older Bootstrap versions). Also, removed "include_strip" from user_panel.html in "Classic" theme; the tag stopped Mezzanine from running.