### PR TITLE
Remove ConstantIncludeNode as it was removed in django 1.7

### DIFF
--- a/mezzanine_themes/business/templatetags/include_strip.py
+++ b/mezzanine_themes/business/templatetags/include_strip.py
@@ -2,11 +2,7 @@ from django import template
 register = template.Library()
 
 from django.template.loader_tags import do_include
-from django.template.loader_tags import ConstantIncludeNode, IncludeNode
-
-class StripConstantIncludeNode(ConstantIncludeNode):
-    def render(self, context):
-        return super(StripConstantIncludeNode, self).render(context).strip()
+from django.template.loader_tags import IncludeNode
 
 class StripIncludeNode(IncludeNode):
     def render(self, context):
@@ -14,10 +10,7 @@ class StripIncludeNode(IncludeNode):
 
 def do_include_strip(parser, token):
     result = do_include(parser, token)
-    if isinstance(result, ConstantIncludeNode):
-        result.__class__ = StripConstantIncludeNode
-    elif isinstance(result, IncludeNode):
-        result.__class__ = StripIncludeNode
+    result.__class__ = StripIncludeNode
     return result
 
 register.tag('include_strip', do_include_strip)

--- a/mezzanine_themes/classic/templatetags/include_strip.py
+++ b/mezzanine_themes/classic/templatetags/include_strip.py
@@ -2,11 +2,7 @@ from django import template
 register = template.Library()
 
 from django.template.loader_tags import do_include
-from django.template.loader_tags import ConstantIncludeNode, IncludeNode
-
-class StripConstantIncludeNode(ConstantIncludeNode):
-    def render(self, context):
-        return super(StripConstantIncludeNode, self).render(context).strip()
+from django.template.loader_tags import IncludeNode
 
 class StripIncludeNode(IncludeNode):
     def render(self, context):
@@ -14,10 +10,7 @@ class StripIncludeNode(IncludeNode):
 
 def do_include_strip(parser, token):
     result = do_include(parser, token)
-    if isinstance(result, ConstantIncludeNode):
-        result.__class__ = StripConstantIncludeNode
-    elif isinstance(result, IncludeNode):
-        result.__class__ = StripIncludeNode
+    result.__class__ = StripIncludeNode
     return result
 
 register.tag('include_strip', do_include_strip)


### PR DESCRIPTION
Compatibilty for Django 1.9
